### PR TITLE
[STEP 2] Add LangChain4j 1.10.0 dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,25 @@ repositories {
 }
 
 dependencies {
+    // Spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework:spring-webflux'
+
+    // LangChain4j BOM (pins everything to 1.10.0)
+    implementation platform('dev.langchain4j:langchain4j-bom:1.10.0')
+
+    // LangChain4j core + Anthropic
+    implementation 'dev.langchain4j:langchain4j'
+    implementation 'dev.langchain4j:langchain4j-anthropic'
+
+    // Optional: JDK HTTP client integration
+    implementation 'dev.langchain4j:langchain4j-http-client-jdk'
+
+    // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation 'io.projectreactor:reactor-test'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Closes #8

Adds LangChain4j BOM 1.10.0, core, Anthropic, HTTP client, Mockito, and reactor-test dependencies.